### PR TITLE
fix: delete guild from db when bot leaves server

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -56,3 +56,7 @@ func SetServerOption(guildID, option, optionValue string) error {
 	_, err := dbase.Exec(fmt.Sprintf("REPLACE INTO guilds (guildID, %s) VALUES(?, ?);", option), guildID, optionValue)
 	return err
 }
+func RemoveServer(guildID string) error {
+	_, err := dbase.Exec("DELETE FROM guilds WHERE guildID = ?", guildID)
+	return err
+}

--- a/main.go
+++ b/main.go
@@ -245,7 +245,7 @@ func handleFakeGiftMessage(s *discordgo.Session, m *discordgo.MessageCreate, l s
 	// gather what action to take
 	var action string
 	err := db.GetServerOption(m.GuildID, "action", &action)
-	if err == sql.ErrNoRows {
+	if err == sql.ErrNoRows || action == "" {
 		action = "kick"
 	}
 

--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ func main() {
 	log.Println("Registered all Commands successfully...")
 
 	dg.AddHandler(guildCreate)
+	dg.AddHandler(guildDelete)
 	dg.AddHandler(messageCreate)
 	log.Println("On the lookout for fake gift messages..")
 
@@ -142,6 +143,11 @@ func guildCreate(s *discordgo.Session, c *discordgo.GuildCreate) {
 			Color:       0x00ff00,
 		})
 		commands.RegisterCommands(s, c.ID)
+	}
+}
+func guildDelete(s *discordgo.Session, c *discordgo.GuildDelete) {
+	if err := db.RemoveServer(c.ID); err != nil {
+		log.Printf("Error occurred when trying to delete guild from db:\n%s", err)
 	}
 }
 


### PR DESCRIPTION
This pr implements some janitor work -> When the bot get's removed from a server, it will remove the server from it's db

additionally, a small bugfix where setting a logChannel would return an empty action in the notification message